### PR TITLE
singleMatch public

### DIFF
--- a/lib/searchjs.js
+++ b/lib/searchjs.js
@@ -194,6 +194,7 @@
 		return(matched);
 	};
 
+	exports.singleMatch = singleMatch;
 	exports.matchArray = matchArray;
 	exports.matchObject = matchObj;
 	exports.deepField = deepField;


### PR DESCRIPTION
This may not seem like much of a big deal but here is the issue I have at hand.

I'm creating a key listener that runs functions based off a JSON configuration.
```json
[{
 "key" : {"somequery" : "tovalidate"},
  "method" : "deep.select.for.function",
  "arguments" : ["a", 2, { "valueType" : "mathjs", "eval" : "f(x) = x - 95"}]
}]
```

Because the listener must check if the key matches it, I therefore am put in situation where I cannot use searchjs to match the value normally.
