### PR TITLE
Added start and end properties to be able to filter from begin and end of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ There are two variants on text search that can expand your ability to search tex
 
 1. substring: if you set the flag `{_text: true}` as part of your search, then it searches for your match *as part of the field*. In other words, if your search is `{name:"davi", _text:true}` then it will check if the field matches `/davi/i`.
 2. word: if you set the flag `{_word: true}` as part of your search, then it search for your match *as a complete word in the field*. In other words, if your search is `{name:"davi",_word:true}` then it will check if the field matches `/\bdavi\b/i`.
+3. start: if you set the flag `{_start: true}` as part of your search, then it search for your match *as a part of begin of the field*. In other words, if your search is `{name:"davi",_start:true}` then it will check if the field matches `/^davi/i`.
+4. end: if you set the flag `{_word: true}` as part of your search, then it search for your match *as a part end of the field*. In other words, if your search is `{name:"davi",_end:true}` then it will check if the field matches `/davi$/i`.
 
 The `_text` option will override the `_word` option if both exist.
 
@@ -199,6 +201,9 @@ Here are some examples of text searching:
 * `{name:"davi"}` matches all of `{name:"davi"}, {name:"DAvi"}` but none of `{name:"david"}, {name:"abc davi def"}`
 * `{name:"davi",_word:true}` matches all of `{name:"davi"}, {name:"DAvi"}, {name:"abc davi def"}` but none of `{name:"david"}`
 * `{name:"davi",_text:true}` matches all of `{name:"davi"}, {name:"DAvi"}, {name:"abc davi def"}, {name:"abdavideq"}`
+* `{name:"davi",_start:true}` matches all of `{name:"davi"}, {name:"DAvi"}, {name:"davideq"}` but none of `{name:"abc davi def"}`
+* `{name:"davi",_end:true}` matches all of `{name:"asdadavi"}, {name:"asdsadDAvi"}` but none of `{name:"abdavideq"},{name:"abc davi def"}`
+
 
 #### Deep Search Separator
 

--- a/lib/searchjs.js
+++ b/lib/searchjs.js
@@ -1,7 +1,7 @@
 /*jslint node:true,nomen:true */
 (function(exports){
 	var matchObj, _matchObj, _getOptions, _getSingleOpt, matchArray, singleMatch, deepField, _defaults = {}, setDefaults, resetDefaults;
-	
+
 
 	// Allows to overwrite the global default values
 	setDefaults = function(options) {
@@ -9,7 +9,7 @@
 			_defaults[key] = options[key];
 		}
 	};
-	
+
 	resetDefaults = function () {
 		_defaults = {};
 	};
@@ -110,8 +110,8 @@
 
 		return ret;
 	};
-	
-	singleMatch = function(field,s,text,word) {
+
+	singleMatch = function(field,s,text,word,start,end) {
 		var oneMatch = false, t, re, j, from, to;
 		// for numbers, exact match; for strings, ignore-case match; for anything else, no match
 		t = typeof(field);
@@ -125,7 +125,7 @@
 			if (s !== null && s !== undefined && typeof(s) === "object" && (s.from !== undefined || s.to !== undefined || s.gt !== undefined || s.lt !== undefined)) {
 				from = s.from || s.gt;
 				to = s.to || s.lt;
-				oneMatch = (s.from !== undefined || s.gt !== undefined ? field >= from : true) && 
+				oneMatch = (s.from !== undefined || s.gt !== undefined ? field >= from : true) &&
 										(s.to !== undefined || s.lt !== undefined ? field <= to: true);
 			} else {
 				oneMatch = field === s;
@@ -140,6 +140,12 @@
 			} else if (word) {
 				re = new RegExp("(\\s|^)"+s+"(?=\\s|$)","i");
 				oneMatch = field && field.match(re) !== null;
+			} else if (start) {
+				re = new RegExp("^"+s, "i");
+				oneMatch = field && field.match(re) !== null;
+			} else if (end) {
+				re = new RegExp(s+"$" , "i");
+				oneMatch = field && field.match(re) !== null;
 			} else {
 				oneMatch = s === field;
 			}
@@ -148,7 +154,7 @@
 		} else if (field.length !== undefined) {
 		  // array, so go through each
 		  for (j=0;j<field.length;j++) {
-		    oneMatch = singleMatch(field[j],s,text,word);
+		    oneMatch = singleMatch(field[j],s,text,word,start,end);
         if (oneMatch) {
           break;
         }
@@ -187,7 +193,7 @@
 		}
 		return ret;
 	};
-	
+
   _getOptions = function(search) {
     var options = {};
 
@@ -200,11 +206,12 @@
     //options.joinAnd = search._join && search._join === "OR" ? false : _defaults.join || true;
     options.joinAnd = _getSingleOpt(search._join,_defaults.join,"AND") === "OR" ? false : true;
 
-    // did we have text or word search?
-    //options.text = search._text ? true : _defaults.text || false;
+    // did we have text, word, start or end search?
     options.text = _getSingleOpt(search._text,_defaults.text,false);
-    //options.word = search._word ? true : _defaults.word || false;
-    options.word = _getSingleOpt(search._word,_defaults.word,false);
+	options.word = _getSingleOpt(search._word,_defaults.word,false);
+	options.start = _getSingleOpt(search._start,_defaults.start,false);
+	options.end = _getSingleOpt(search._end,_defaults.end,false);
+
     options.separator = search._separator || _defaults.separator || '.';
     options.propertySearch = _getSingleOpt(search._propertySearch,_defaults.propertySearch,false);
     options.propertySearchDepth = _getSingleOpt(search._propertySearchDepth,_defaults.propertySearchDepth,-1);
@@ -212,7 +219,7 @@
 
     return options;
   };
-	
+
 	_matchObj = function(obj,search,options) {
 		var i, j, matched, oneMatch, ary, searchTermParts;
 		search = search || {};
@@ -245,7 +252,7 @@
 					searchTermParts = i.split(options.separator);
 				  ary = [].concat(search[i]);
 			    for (j=0;j<ary.length;j++) {
-						oneMatch = singleMatch(deepField(obj,searchTermParts,options.propertySearch,options.propertySearchDepth),ary[j],options.text,options.word);
+						oneMatch = singleMatch(deepField(obj,searchTermParts,options.propertySearch,options.propertySearchDepth),ary[j],options.text,options.word,options.start,options.end);
             if (oneMatch) {
               break;
             }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "should": "^1.3.0"
   },
   "scripts": {
-    "test": "node ./test/test.js"
+    "test": "./node_modules/mocha/bin/mocha ./test/test.js --reporter spec"
   },
   "dependencies": {}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,8 @@ searches = [
 	{search: {"level3.level4.level6":200, _propertySearch:true, _propertySearchDepth: 6}, results:[6]},
 	{search: {"level6":{gt:100,lt:300}, _propertySearch:true},results:[6]},
 	{search: {"terms":[{"level6":{gt:100}, _propertySearch:true}, {"level1.level6":{lt:300}, _propertySearch:true}]},results:[6]},
+	{search: {name:"bri",_start:true}, results:[1]},
+	{search: {name:"n",_end:true}, results:[1,6]},
 ];
 
 
@@ -205,6 +207,40 @@ describe('searchjs', function(){
 			});
 			it('should match not text with explicit override', function(){
 				search.matchArray(data,{fullname:"alice",_word:false}).should.eql(noword);
+			});
+		});
+		describe('start', function(){
+			var yesword, noword;
+			before(function(){
+				yesword = search.matchArray(data,{fullname:"car",_start:true});
+				noword = search.matchArray(data,{fullname:"cari"});
+				search.setDefaults({start:true});
+			});
+			after(function () {
+				search.resetDefaults();
+			});
+			it('should match begin text without explicit _start', function(){
+				search.matchArray(data,{fullname:"car"}).should.eql(yesword);
+			});
+			it('should match not begin text with explicit override', function(){
+				search.matchArray(data,{fullname:"alice",_start:false}).should.eql(noword);
+			});
+		});
+		describe('end', function(){
+			var yesword, noword;
+			before(function(){
+				yesword = search.matchArray(data,{fullname:"rie",_end:true});
+				noword = search.matchArray(data,{fullname:"arie"});
+				search.setDefaults({end:true});
+			});
+			after(function () {
+				search.resetDefaults();
+			});
+			it('should match end text without explicit _end', function(){
+				search.matchArray(data,{fullname:"rie"}).should.eql(yesword);
+			});
+			it('should match not begin text with explicit override', function(){
+				search.matchArray(data,{fullname:"arie",_end:false}).should.eql(noword);
 			});
 		});
 		describe('separator', function(){


### PR DESCRIPTION
Added the start and end properties allow filter by beginning or ending of a string.

Also changed the `npm test` script in packages.json to: `"test": "./node_modules/mocha/bin/mocha ./test/test.js --reporter spec"` to run properly.