### PR TITLE
add module property to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchjs",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "searchjs",
   "description": "A library for filtering JavaScript objects based on a json SQL-like language, jsql",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "url": "http://github.com/deitch/searchjs",
   "author": "Avi Deitcher (https://github.com/deitch)",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=0.8"
   },
   "main": "./lib/searchjs.js",
+  "module": "src/searchjs.js",
   "files": [
     "/lib"
   ],


### PR DESCRIPTION
Thanks so much for your incredbile work on `searchjs`.  I plan to integrate into [`parcoord-es`](https://github.com/BigFatDog/parcoords-es/issues/45).

### rollup and the module property

I struggled with simple `import { matchArray } from 'searchjs` in an outside project, which generally works as expected.  I discovered through this [`StackOverflow discussion`](https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for) that the problem was coming from `rollup` and a missing `module` property in package.json.  Adding the `module` property resolved my issue.
